### PR TITLE
Add a gpg rule.

### DIFF
--- a/tests/package_managers/apt_get/BUILD
+++ b/tests/package_managers/apt_get/BUILD
@@ -1,7 +1,10 @@
 package(default_visibility = ["//visibility:public"])
 
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
 load("//package_managers/apt_get:apt_get.bzl", "generate_apt_get")
-load("//package_managers/apt_get:repos.bzl", "generate_additional_repos")
+load("//package_managers/apt_get:repos.bzl", "generate_additional_repos", "add_gpg_key_from_url")
+load("//util:run.bzl", "container_run_and_commit")
+load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 load(
     "@bazel_tools//tools/build_rules:test_rules.bzl",
     "rule_test",
@@ -75,4 +78,28 @@ set -x
 
 tar -xvf tests/package_managers/test_download_pkgs.tar && dpkg -i ./*.deb && apt-get install -f""",
     file = ":test_apt_get_from_tar",
+)
+
+# The gpg rules need a base image with curl and gnupg2.
+container_run_and_commit(
+    name = "test_gpg_base",
+    commands = ["apt-get update && apt-get install -y curl gnupg2"],
+    image = "//debian/reproducible:debian9",
+)
+
+docker_build(
+    name = "test_gpg_base_image",
+    base = ":test_gpg_base",
+)
+
+add_gpg_key_from_url(
+    name = "test_gpg_image",
+    gpg_url = "https://bazel.build/bazel-release.pub.gpg",
+    image = ":test_gpg_base_image",
+)
+
+structure_test(
+    name = "test_gpg",
+    config = ":gpg.yaml",
+    image = ":test_gpg_image",
 )

--- a/tests/package_managers/apt_get/gpg.yaml
+++ b/tests/package_managers/apt_get/gpg.yaml
@@ -1,0 +1,6 @@
+schemaVersion: '2.0.0'
+commandTests:
+- name: 'gpg'
+  command: 'apt-key'
+  args: ['list']
+  expectedOutput: ['Bazel APT repository key']

--- a/util/commit.sh.tpl
+++ b/util/commit.sh.tpl
@@ -6,6 +6,9 @@ set -ex
 
 id=$(docker run -d %{image} %{commands})
 
+# Attach can fail if the container has already stopped.
+docker attach $id || true
+
 docker commit $id %{output_image}
 docker save %{output_image} -o %{output_tar}
 docker rm $id


### PR DESCRIPTION
I'm not super happy with the implementation - ideally we could reference the GPG key url as a WORKSPACE dependency, but I'm not sure how to pass that file into the image so that apt-key add can reference it.

Any ideas?

cc @xingao267