### PR TITLE
Use File.path instead of File.short_path.

### DIFF
--- a/package_managers/apt_get/apt_get.bzl
+++ b/package_managers/apt_get/apt_get.bzl
@@ -69,7 +69,7 @@ def _impl(ctx):
 
     download_commands = _generate_download_commands(ctx) if ctx.attr.packages else []
     tar_name = ("{0}.tar".format(ctx.attr.name) if ctx.attr.packages
-                else ctx.file.tar.short_path)
+                else ctx.file.tar.path)
     install_commands = _generate_install_commands(ctx, tar_name)
 
     apt_get = package_manager_provider(

--- a/package_managers/install_pkgs.bzl
+++ b/package_managers/install_pkgs.bzl
@@ -51,7 +51,7 @@ fi
 
 cid=$(docker run -d -v $(pwd)/{installables_tar}:/tmp/{installables_tar} -v $(pwd)/{installer_script}:/tmp/installer.sh --privileged {base_image_name} /tmp/installer.sh)
 
-docker attach $cid || true
+docker attach $cid
 docker commit -c "CMD $old_cmd" $cid {output_image_name}
 docker save {output_image_name} > {output_file_name}
 """.format(base_image_tar=ctx.file.image_tar.path,


### PR DESCRIPTION
short_path does not work for generated files.

Ref:
https://docs.bazel.build/versions/master/skylark/lib/File.html#path