### PR TITLE
Remove unnecessary dollar sign.

### DIFF
--- a/package_managers/download_pkgs.bzl
+++ b/package_managers/download_pkgs.bzl
@@ -50,7 +50,7 @@ def _impl(ctx):
 set -ex
 docker load --input {image_tar}
 # Run the builder image.
-cid=$(docker run -d --privileged {image_name} sh -c $'{download_commands}')
+cid=$(docker run -d --privileged {image_name} sh -c '{download_commands}')
 docker attach $cid
 docker cp $cid:{installables}.tar {output}
 # Cleanup


### PR DESCRIPTION
This dollar sign seems unnecessary and is breaking our tests. It does cause issue in local runs, but cause issue in our Jenkins test: https://ci.bazel.io/blue/organizations/jenkins/CR%2Fbazel-toolchains/detail/bazel-toolchains/30/pipeline/.