### PR TITLE
Temporarily force debootstrap to use a specific IP for

### DIFF
--- a/debian/reproducible/debootstrap.bzl
+++ b/debian/reproducible/debootstrap.bzl
@@ -29,7 +29,7 @@ set -ex
 # Execute the loader script.
 {0}
 # Run the builder image.
-cid=$(docker run -d --privileged {1} {2} {3})
+cid=$(docker run -d --add-host snapshot.debian.org:193.62.202.30 --privileged {1} {2} {3})
 docker attach $cid
 # Copy out the rootfs.
 docker cp $cid:/workspace/rootfs.tar.gz {4}


### PR DESCRIPTION
snapshot.debian.org.

The server at the primary IP (according to DNS) is having issues. This temporarily allows us to build using the other server.