### PR TITLE
Fix path for _image_utils attribute.

### DIFF
--- a/package_managers/install_pkgs.bzl
+++ b/package_managers/install_pkgs.bzl
@@ -55,7 +55,7 @@ docker attach $cid || true
 
 reset_cmd {base_image_name} $cid {output_image_name}
 docker save {output_image_name} > {output_file_name}
-""".format(util_script=ctx.file._image_utils.short_path,
+""".format(util_script=ctx.file._image_utils.path,
            base_image_tar=ctx.file.image_tar.path,
            base_image_name=builder_image_name,
            installables_tar=installables_tar,


### PR DESCRIPTION
I got this error message when install_pkgs rule is referenced as an external repository.

ERROR: /usr/local/google/home/xingao/gitrepos/bazel-toolchains/rules/BUILD:31:1: SkylarkAction rules/debian8-clang-with-pkgs.tar.unstripped failed (Exit 1)
+ source ../base_images_docker/util/image_util.sh
bazel-out/k8-fastbuild/bin/rules/debian8-clang-with-pkgs.build: line 4: ../base_images_docker/util/image_util.sh: No such file or directory


With this change, when referencing externally, the correct path (external/base_images_docker/util/image_util.sh) is used.
  