### PR TITLE
Add a dockerfile_build macro that wraps the tar output in a docker_build

### DIFF
--- a/dockerfile_build/dockerfile_build.bzl
+++ b/dockerfile_build/dockerfile_build.bzl
@@ -14,6 +14,8 @@
 
 """Rule for building debootstrap rootfs tarballs."""
 
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build")
+
 def _impl(ctx):
     dockerfile_path = ctx.file.dockerfile.path
 
@@ -99,7 +101,7 @@ docker save {tag} > {output}
 
     return struct()
 
-dockerfile_build = rule(
+_dockerfile_build = rule(
     attrs = {
         "base": attr.label(
             allow_files = True,
@@ -133,3 +135,15 @@ dockerfile_build = rule(
     },
     implementation = _impl,
 )
+
+def dockerfile_build(name, *args, **kwargs):
+    intermediate_name = "%s-intermediate" % name
+    _dockerfile_build(
+        name=intermediate_name,
+        *args,
+        **kwargs
+    )
+    docker_build(
+        name=name,
+        base=intermediate_name + ".tar"
+    )

--- a/node/reproducible/BUILD
+++ b/node/reproducible/BUILD
@@ -30,7 +30,7 @@ sh_binary(
 # on top of a vanilla ubuntu_%s release
 [[docker_build(
     name = "node_%s_ubuntu_%s" % (node_version, ubuntu_version),
-    base = "//ubuntu:ubuntu_%s_dockerbuild" % ubuntu_version,
+    base = "//ubuntu:ubuntu_%s" % ubuntu_version,
     env = NODEJS_ENV,
     ports = ["8080"],
     tars = [

--- a/tests/dockerfile_build/BUILD
+++ b/tests/dockerfile_build/BUILD
@@ -1,8 +1,8 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//dockerfile_build:dockerfile_build.bzl", "dockerfile_build")
-load("@runtimes_common//structure_tests:tests.bzl", "structure_test")
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel_rules_docker//contrib:test.bzl", "container_test")
 
 pkg_tar(
     name = "context",
@@ -18,20 +18,20 @@ dockerfile_build(
     dockerfile = ":Dockerfile",
 )
 
-structure_test(
+container_test(
     name = "dockerfile_build_test",
-    config = ":test.yaml",
-    image_tar = ":test_image",
+    configs = [":test.yaml"],
+    image = ":test_image",
 )
 
 dockerfile_build(
     name = "test_image_2",
-    base_tar = ":test_image",
+    base_tar = ":test_image.tar",
     dockerfile = ":Dockerfile.2",
 )
 
-structure_test(
+container_test(
     name = "dockerfile_build_test_2",
-    config = ":test2.yaml",
-    image_tar = ":test_image_2",
+    configs = [":test2.yaml"],
+    image = ":test_image_2",
 )

--- a/ubuntu/BUILD
+++ b/ubuntu/BUILD
@@ -8,14 +8,18 @@ UBUNTU_VERSIONS = [
     "16_0_4",
 ]
 
+# 'ubuntu_%s' is a ubuntu_%s rootfs w/ ca-certificates, curl, and netbase
+# This image is used for node images. Look node/reproducible/BUILD#L31
 [dockerfile_build(
-    name = "ubuntu_%s_dockerbuild" % version,
+    name = "ubuntu_%s" % version,
     base = ":ubuntu_%s_vanilla" % version,
     dockerfile = ":Dockerfile.ubuntu",
 ) for version in UBUNTU_VERSIONS]
 
+# 'ubuntu_%s_build' is the 'ubuntu_%s' image w/ build-essential and python2.7
+#  This image is used for node images. Look node/reproducible/BUILD#L41
 [dockerfile_build(
-    name = "ubuntu_%s_build_dockerbuild" % version,
+    name = "ubuntu_%s_build" % version,
     base = ":ubuntu_%s" % version,
     dockerfile = ":Dockerfile.ubuntu_build",
 ) for version in UBUNTU_VERSIONS]
@@ -37,21 +41,4 @@ pkg_tar(
     name = "ubuntu_%s_vanilla" % version,
     env = UBUNTU_ENV,
     tars = ["@ubuntu_%s_tar_download//file" % version],
-) for version in UBUNTU_VERSIONS]
-
-# 'ubuntu_%s' is a ubuntu_%s rootfs w/ ca-certificates, curl, and netbase
-# This image is used for node images. Look node/reproducible/BUILD#L31
-[docker_build(
-    name = "ubuntu_%s" % version,
-    base = "//ubuntu:ubuntu_%s_dockerbuild.tar" % version,
-    tars = [
-        ":overlay.tar",
-    ],
-) for version in UBUNTU_VERSIONS]
-
-# 'ubuntu_%s_build' is the 'ubuntu_%s' image w/ build-essential and python2.7
-#  This image is used for node images. Look node/reproducible/BUILD#L41
-[docker_build(
-    name = "ubuntu_%s_build" % version,
-    base = "//ubuntu:ubuntu_%s_build_dockerbuild.tar" % version,
 ) for version in UBUNTU_VERSIONS]


### PR DESCRIPTION
rule.

This makes it easier to use these in other dependent rules.

Signed-off-by: dlorenc <dlorenc@google.com>