### PR TITLE
Don't delete /tmp itself, just the contents.

### DIFF
--- a/package_managers/installer.sh.tpl
+++ b/package_managers/installer.sh.tpl
@@ -8,4 +8,4 @@ pushd /tmp
 popd
 umount -l /tmp/installer.sh
 umount -l /tmp/%{installables_tar}
-rm -rf /tmp
+rm -rf /tmp/*


### PR DESCRIPTION
I hit this in working on #153. Some tools expect a /tmp dir to exist.