### PR TITLE
Allow multiple container_run_and_extract extracting file with same name.

### DIFF
--- a/tests/util/BUILD
+++ b/tests/util/BUILD
@@ -44,14 +44,14 @@ container_run_and_extract(
 rule_test(
     name = "test_container_extract_rule",
     generates = [
-        "foo.txt",
+        "test_container_extract/foo.txt",
     ],
     rule = "test_container_extract",
 )
 
 file_test(
     name = "test_extracted_file",
-    file = ":foo.txt",
+    file = "test_container_extract/foo.txt",
     regexp = "test",
 )
 

--- a/util/run.bzl
+++ b/util/run.bzl
@@ -230,7 +230,7 @@ def container_run_and_extract(name, image, commands, extract_file):
         image_tar = image_tar + ".tar",
         commands = commands,
         extract_file = extract_file,
-        output_file = extract_file.lstrip("/"),
+        output_file = name + extract_file,
     )
 
 def _process_commands(command_list):


### PR DESCRIPTION
When multiple container_run_and_extract rules are extracting the same
file, the name of the output file will conflict with each other. So
instead of putting the file in the root directory of output file tree,
putting the output file in <root>/<name_of_the_rule>/