### PR TITLE
Remove apt-get cache before apt-get update.

### DIFF
--- a/package_managers/download_pkgs.bzl
+++ b/package_managers/download_pkgs.bzl
@@ -21,6 +21,8 @@ def _generate_download_commands(ctx):
     return """#!/bin/bash
 set -ex
 # Fetch Index
+# Remove /var/lib/apt/lists/* in the base image. apt-get update -y command will create them.
+rm -rf /var/lib/apt/lists/*
 apt-get update -y
 # Make partial dir
 mkdir -p /tmp/install/./partial


### PR DESCRIPTION
To avoid conflict between existing cache and newly fetched index.

Example error:
W: Size of file /var/lib/apt/lists/archive.ubuntu.com_ubuntu_dists_trusty-backports_main_binary-amd64_Packages.gz is not what the server reported 14713 14809