### PR TITLE
Always run download script in docker with workdir "/"

### DIFF
--- a/package_managers/download_pkgs.bzl
+++ b/package_managers/download_pkgs.bzl
@@ -59,7 +59,7 @@ def _impl(ctx):
 set -ex
 docker load --input {image_tar}
 # Run the builder image.
-cid=$(docker run -d --privileged {image_name} sh -c $'{download_commands}')
+cid=$(docker run -w="/" -d --privileged {image_name} sh -c $'{download_commands}')
 docker attach $cid
 docker cp $cid:{installables}.tar {output}
 # Cleanup

--- a/tests/package_managers/BUILD
+++ b/tests/package_managers/BUILD
@@ -31,7 +31,7 @@ rule_test(
 file_test(
     name = "test_download_pkgs_docker_run",
     file = ":test_download_pkgs",
-    regexp = ".*docker run -d --privileged bazel/tests/package_managers:test_download_pkgs_build sh -c $'.*",
+    regexp = ".*docker run -w=\"/\" -d --privileged bazel/tests/package_managers:test_download_pkgs_build sh -c $'.*",
 )
 
 file_test(


### PR DESCRIPTION
The deb package tarball will be created under ${WORKDIR}/ in the docker
container while the 'docker cp' command which copies the tarball outside
the contaienr expect the tarball to be at /. If WORKDIR of the base
container is set to a path other than /, the 'docker cp' command will
fail.