### PR TITLE
Fix quotation mark when constructing bazel cmds.

### DIFF
--- a/bootstrap_image.sh
+++ b/bootstrap_image.sh
@@ -32,14 +32,16 @@ if [ -z "${GIT_ROOT}" ]; then
 fi
 
 echo "Running bazel build ${TARGET}"
+# shellcheck disable=SC2086
 bazel build "${TARGET}" \
-    --action_env=GIT_ROOT="${GIT_ROOT}" \
-    --sandbox_writable_path="${GIT_ROOT} ${DEBUG}"
+  --action_env=GIT_ROOT="${GIT_ROOT}" \
+  --sandbox_writable_path="${GIT_ROOT}" ${DEBUG}
 
 # get rid of running this once we figure out how to make put_status output mandatory in bootstrap_image.
 echo "Running bazel build ${TARGET}_fetch to make we store the downloaded packages in the store back"
+# shellcheck disable=SC2086
 bazel build "${TARGET}_fetch" \
   --action_env=GIT_ROOT="${GIT_ROOT}" \
-  --sandbox_writable_path="${GIT_ROOT} ${DEBUG}"
+  --sandbox_writable_path="${GIT_ROOT}" ${DEBUG}
 
 echo "Please run 'git status' and 'git commit' commands to commit  the downloaded packages to the git repository"


### PR DESCRIPTION
Before the change, the bazel cmd constructed is like the following:

bazel build //container/debian8-clang-fully-loaded:bootstrap_rbe_debian8_toolchain --action_env=GIT_ROOT=/my/path '--sandbox_writable_path=/my/path --verbose_failures --sandbox_debug'

This gives error: 

I/O exception during sandboxed execution: /my/path--verbose_failures --sandbox_debug (No such file or directory)
