### PR TITLE
Add installation_cleanup_commands attr in install_pkgs.

### DIFF
--- a/package_managers/bootstrap_image.bzl
+++ b/package_managers/bootstrap_image.bzl
@@ -128,10 +128,10 @@ Args:
        package management tool e.g apt-get, dpkg to downloads packages.
   store: A target to store the downloaded packages or retrieve previously downloaded packages.
   additional_repos: list of additional debian package repos to use, in sources.list format.
-  post_installation_script: extra commands to run after package installation.
+  installation_cleanup_commands: cleanup commands to run after package installation.
 """
 
-def bootstrap_image_macro(name, image_tar, packages, store_location, date, output_image_name, additional_repos=[], post_installation_script=""):
+def bootstrap_image_macro(name, image_tar, packages, store_location, date, output_image_name, additional_repos=[], installation_cleanup_commands=""):
   """Downloads packages within a container
   This rule creates a script to download packages within a container.
   The script bundles all the packages in a tarball.
@@ -140,7 +140,7 @@ def bootstrap_image_macro(name, image_tar, packages, store_location, date, outpu
     image_tar: The image tar for the container used to download packages.
     packages: list of packages to download. e.g. ['curl', 'netbase']
     additional_repos: list of additional debian package repos to use, in sources.list format
-    post_installation_script: extra commands to run after package installation.
+    installation_cleanup_commands: cleanup commands to run after package installation.
   """
   download_target = "{0}_download".format(name)
   download_pkgs(
@@ -164,5 +164,5 @@ def bootstrap_image_macro(name, image_tar, packages, store_location, date, outpu
       image_tar = image_tar,
       installables_tar = ":{0}.tar".format(fetch_target),
       output_image_name = output_image_name,
-      post_installation_script = post_installation_script,
+      installation_cleanup_commands = installation_cleanup_commands,
  )

--- a/package_managers/bootstrap_image.bzl
+++ b/package_managers/bootstrap_image.bzl
@@ -127,10 +127,11 @@ Args:
   package_manager_genrator: A target which generates a script using
        package management tool e.g apt-get, dpkg to downloads packages.
   store: A target to store the downloaded packages or retrieve previously downloaded packages.
-  additional_repos: list of additional debian package repos to use, in sources.list format
+  additional_repos: list of additional debian package repos to use, in sources.list format.
+  post_installation_script: extra commands to run after package installation.
 """
 
-def bootstrap_image_macro(name, image_tar, packages, store_location, date, output_image_name, additional_repos=[]):
+def bootstrap_image_macro(name, image_tar, packages, store_location, date, output_image_name, additional_repos=[], post_installation_script=""):
   """Downloads packages within a container
   This rule creates a script to download packages within a container.
   The script bundles all the packages in a tarball.
@@ -139,6 +140,7 @@ def bootstrap_image_macro(name, image_tar, packages, store_location, date, outpu
     image_tar: The image tar for the container used to download packages.
     packages: list of packages to download. e.g. ['curl', 'netbase']
     additional_repos: list of additional debian package repos to use, in sources.list format
+    post_installation_script: extra commands to run after package installation.
   """
   download_target = "{0}_download".format(name)
   download_pkgs(
@@ -162,4 +164,5 @@ def bootstrap_image_macro(name, image_tar, packages, store_location, date, outpu
       image_tar = image_tar,
       installables_tar = ":{0}.tar".format(fetch_target),
       output_image_name = output_image_name,
+      post_installation_script = post_installation_script,
  )

--- a/package_managers/install_pkgs.bzl
+++ b/package_managers/install_pkgs.bzl
@@ -14,19 +14,19 @@
 
 """Rule for installing apt packages from a tar file into a docker image."""
 
-def _generate_install_commands(tar, post_installation_script):
+def _generate_install_commands(tar, installation_cleanup_commands):
   return """
 tar -xvf {tar}
 dpkg -i --force-depends ./*.deb
 dpkg --configure -a
 apt-get install -f
-{post_installation_script}
+{installation_cleanup_commands}
 # delete the files that vary build to build
 rm -f /var/log/dpkg.log
 rm -f /var/log/alternatives.log
 rm -f /var/cache/ldconfig/aux-cache
 rm -f /var/cache/apt/pkgcache.bin
-touch /run/mount/utab""".format(tar=tar, post_installation_script=post_installation_script)
+touch /run/mount/utab""".format(tar=tar, installation_cleanup_commands=installation_cleanup_commands)
 
 def _impl(ctx):
   installables_tar = ctx.file.installables_tar.path
@@ -35,7 +35,7 @@ def _impl(ctx):
   ctx.template_action(
       template=ctx.file._installer_tpl,
       substitutions= {
-          "%{install_commands}": _generate_install_commands(installables_tar, ctx.attr.post_installation_script),
+          "%{install_commands}": _generate_install_commands(installables_tar, ctx.attr.installation_cleanup_commands),
           "%{installables_tar}": installables_tar,
       },
       output = install_script,
@@ -103,7 +103,7 @@ install_pkgs = rule(
             single_file = True,
             mandatory = True,
         ),
-        "post_installation_script": attr.string(
+        "installation_cleanup_commands": attr.string(
             default = "",
         ),
         "output_image_name": attr.string(


### PR DESCRIPTION
This enable users to execute commands after installing deb packages. It
is very useful, for example, to remove files that vary build to build
specific to a deb package. For python3.4 installation, .pyc files under
/usr/lib/python3.4/__pycache__/ vary from build to build. With this
extra attribute, if users want to install python3.4 and ensure
reproducibility, they can set post_installation_script to be "rm -rf
/usr/lib/python3.4/__pycache__/".

This commit also adds removing /var/log/alternatives.log as part of
every package installation.